### PR TITLE
Added Ukrainian translation .po

### DIFF
--- a/package/translate/uk.po
+++ b/package/translate/uk.po
@@ -1,0 +1,152 @@
+# Translation of OnzeMenu in Ukrainian
+# Copyright (C) 2023
+# This file is distributed under the same license as the OnzeMenu package.
+# Mykhailo Stetsiuk <yaBobJonez@gmail.com>, 2023.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: OnzeMenu\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-04-02 23:21-0300\n"
+"PO-Revision-Date: 2023-04-07 HO:MI+ZONE\n"
+"Last-Translator: Mykhailo Stetsiuk <yaBobJonez@gmail.com>\n"
+"Language-Team: \n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../metadata.desktop
+msgid "OnzeMenu 11"
+msgstr "OnzeMenu 11"
+
+#: ../metadata.desktop
+msgid "A configurable launcher menu 11"
+msgstr "Налаштовуваний засіб запуску програм 11"
+
+#: ../contents/config/config.qml
+msgid "General"
+msgstr "Загальне"
+
+#: ../contents/ui/code/tools.js
+msgid "Remove from Favorites"
+msgstr "Вилучити з улюблених"
+
+#: ../contents/ui/code/tools.js
+msgid "Add to Favorites"
+msgstr "Додати до улюблених"
+
+#: ../contents/ui/code/tools.js
+msgid "On All Activities"
+msgstr "У всіх просторах дій"
+
+#: ../contents/ui/code/tools.js
+msgid "On the Current Activity"
+msgstr "У поточному просторі дій"
+
+#: ../contents/ui/code/tools.js
+msgid "Show in Favorites"
+msgstr "Показати в улюблених"
+
+#: ../contents/ui/ConfigGeneral.qml
+msgid "Icon:"
+msgstr "Піктограма:"
+
+#: ../contents/ui/ConfigGeneral.qml
+msgctxt "@item:inmenu Open icon chooser dialog"
+msgid "Choose..."
+msgstr "Вибрати..."
+
+#: ../contents/ui/ConfigGeneral.qml
+msgctxt "@item:inmenu Reset icon to default"
+msgid "Clear Icon"
+msgstr "Прибрати піктограму"
+
+#: ../contents/ui/ConfigGeneral.qml
+msgid "Menu position"
+msgstr "Розташування меню"
+
+#: ../contents/ui/ConfigGeneral.qml
+msgid "Default"
+msgstr "За замовчуванням"
+
+#: ../contents/ui/ConfigGeneral.qml
+msgid "Center"
+msgstr "Центр"
+
+#: ../contents/ui/ConfigGeneral.qml
+msgid "Center bottom"
+msgstr "Центр знизу"
+
+#: ../contents/ui/ConfigGeneral.qml
+msgid "Expand search to bookmarks, files and emails"
+msgstr "Розширення пошуку на закладки, файли та електронну пошту"
+
+#: ../contents/ui/ConfigGeneral.qml
+msgid "Show labels in two lines"
+msgstr "Відображати пункти у два рядки"
+
+#: ../contents/ui/ConfigGeneral.qml
+msgid "Number of columns (main grid)"
+msgstr "Кількість стовпців"
+
+#: ../contents/ui/ConfigGeneral.qml
+msgid "Number of rows (main grid)"
+msgstr "Кількість рядків"
+
+#: ../contents/ui/ConfigGeneral.qml
+msgid "Icons smooth"
+msgstr "Згладжування піктограм"
+
+#: ../contents/ui/ConfigGeneral.qml
+msgid "Size of icons"
+msgstr "Розмір піктограм"
+
+#: ../contents/ui/Footer.qml
+msgid "User Home"
+msgstr "Домівка"
+
+#: ../contents/ui/Footer.qml
+msgid "System Preferences"
+msgstr "Системні параметри"
+
+#: ../contents/ui/Footer.qml
+msgid "Lock Screen"
+msgstr "Заблокувати"
+
+#: ../contents/ui/Footer.qml
+msgid "Leave ..."
+msgstr "Вийти..."
+
+#: ../contents/ui/main.qml
+msgid "Edit Applications…"
+msgstr "Змінити список програм…"
+
+#: ../contents/ui/MenuRepresentation.qml
+msgid "Type here to search ..."
+msgstr "Введіть текст для пошуку"
+
+#: ../contents/ui/MenuRepresentation.qml
+msgid "Search results"
+msgstr "Результати пошуку"
+
+#: ../contents/ui/MenuRepresentation.qml
+msgid "Pinned"
+msgstr "Закріплені"
+
+#: ../contents/ui/MenuRepresentation.qml
+msgid "All apps"
+msgstr "Усі програми"
+
+#: ../contents/ui/MenuRepresentation.qml
+msgid "Recommended"
+msgstr "Рекомендовані"
+
+#: ../contents/ui/MenuRepresentation.qml
+msgid "Back"
+msgstr "Назад"
+
+#: ../contents/ui/MenuRepresentation.qml
+msgid "More"
+msgstr "Додатково"


### PR DESCRIPTION
Hello, this is my first translation contribution, so I hope I did everything right ;)
As instructed in the README, I have translated all entries, and also have changed the metadata accordingly.
It seems like OnzeMenu is based on Windows 11 Start, so among in-menu visible labels I picked words that are used in Windows itself, while for settings I chose the terms used in KDE Plasma; well, there are many ways to translate a word, you know...
Thank you for the amazing launcher widget, I'll be happy if this pull request gets accepted!